### PR TITLE
Remove VM reboot

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -814,16 +814,6 @@ func resourceVmQemuUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	// give sometime to bootup
 	time.Sleep(9 * time.Second)
-	if _, err = client.StopVm(vmr); err != nil {
-		pmParallelEnd(pconf)
-		return err
-	}
-
-	time.Sleep(9 * time.Second)
-	if _, err = client.StartVm(vmr); err != nil {
-		pmParallelEnd(pconf)
-		return err
-	}
 
 	pmParallelTransfer(pconf)
 


### PR DESCRIPTION
Preferrebly we should catch-up with the upstream changes, as there
is a change that'll improve upon this logic - making the VM only
reboot once it is required (not on size changes, for example)